### PR TITLE
add feature: object alias

### DIFF
--- a/include/lv_conf_v7.h
+++ b/include/lv_conf_v7.h
@@ -863,6 +863,9 @@ typedef struct {
   // uint8_t swipeid:4;
   void* ext;
   // char* action;
+#if USE_OBJ_ALIAS > 0  
+  uint16_t aliashash;
+#endif  // #if USE_OBJ_ALIAS > 0
 } lv_obj_user_data_t;
 
 /*1: enable `lv_obj_realaign()` based on `lv_obj_align()` parameters*/

--- a/include/user_config_override-template.h
+++ b/include/user_config_override-template.h
@@ -158,5 +158,12 @@
 //#define HASP_DEBUG_OBJ_TREE                         // Output all objects to the log on page changes
 //#define HASP_LOG_LEVEL LOG_LEVEL_VERBOSE            // LOG_LEVEL_* can be DEBUG, VERBOSE, TRACE, INFO, WARNING, ERROR, CRITICAL, ALERT, FATAL, SILENT
 //#define HASP_LOG_TASKS                              // Also log the Taskname and watermark of ESP32 tasks
+#define USE_OBJ_ALIAS 1                             // Enable store object alias und accept commands for objects with alias1
+
+#if USE_OBJ_ALIAS > 0
+#ifndef LV_USE_USER_DATA
+   #define LV_USE_USER_DATA
+#endif
+#endif
 
 #endif // HASP_USER_CONFIG_OVERRIDE_H

--- a/src/hasp/hasp_attribute.cpp
+++ b/src/hasp/hasp_attribute.cpp
@@ -1794,6 +1794,16 @@ static hasp_attribute_type_t attribute_common_text(lv_obj_t* obj, uint16_t attr_
         }
     }
 
+#if USE_OBJ_ALIAS > 0
+    if(attr_hash == ATTR_ALIAS) {
+        if(update) {
+            my_obj_set_alias(obj, attr_hash, payload);
+        } else {
+            *text = (char*)my_obj_get_alias(obj);
+        }
+    }
+#endif  // #if USE_OBJ_ALIAS > 0
+
     return HASP_ATTR_TYPE_STR;
 }
 
@@ -2698,6 +2708,9 @@ void hasp_process_obj_attribute(lv_obj_t* obj, const char* attribute, const char
         //     LOG_WARNING(TAG_HASP, F(D_ATTRIBUTE_OBSOLETE D_ATTRIBUTE_INSTEAD), attribute, "text");
         case ATTR_TEXT:
         case ATTR_TEMPLATE:
+#if USE_OBJ_ALIAS > 0
+        case ATTR_ALIAS:
+#endif  // #if USE_OBJ_ALIAS > 0
             ret = attribute_common_text(obj, attr_hash, payload, &text, update);
             break;
 

--- a/src/hasp/hasp_attribute.h
+++ b/src/hasp/hasp_attribute.h
@@ -501,6 +501,7 @@ _HASP_ATTRIBUTE(SCALE_END_LINE_WIDTH, scale_end_line_width, lv_style_int_t)
 #define ATTR_GROUPID 48986
 #define ATTR_OBJID 41010
 #define ATTR_OBJ 53623
+#define ATTR_ALIAS 33840
 
 #define ATTR_TEXT_MAC 38107
 #define ATTR_TEXT_IP 41785

--- a/src/hasp/hasp_attribute_helper.h
+++ b/src/hasp/hasp_attribute_helper.h
@@ -825,6 +825,42 @@ static uint16_t my_btnmatrix_get_count(const lv_obj_t* btnm)
     return ext->btn_cnt;
 }
 
+#if USE_OBJ_ALIAS > 0
+/**
+ * Find object with given alias
+ * @param obj pointer to perent object
+ * @param alias hash to be searched for
+ * @return Null at the moment in further text of alias
+ */
+static const char* my_obj_get_alias(const lv_obj_t* obj)
+{
+#if LV_USE_USER_DATA
+    if (obj->user_data.aliashash > 0) {
+//        const char hashtext[6] = {0};
+//        itoa(obj->user_data.aliashash, (char*)hashtext, 10);
+//        return hashtext;
+    }
+#endif
+    return NULL;
+}
+
+/**
+ * Set the alias of an object
+ * @param obj pointer to object
+ * @param attr_hash alias hash to store in object user data
+ * @param text alias text - not used further
+ */
+static void my_obj_set_alias(lv_obj_t* obj, uint16_t attr_hash, const char* text)
+{
+#if LV_USE_USER_DATA
+    obj->user_data.aliashash = Parser::get_sdbm(text); 
+
+    LOG_DEBUG(TAG_HASP, "set alias hash [%s] [%d]", text, obj->user_data.aliashash);
+#endif
+    return;
+}
+#endif // USE_OBJ_ALIAS
+
 #if 0
 static bool attribute_lookup_lv_property(uint16_t hash, uint8_t * prop)
 {

--- a/src/hasp/hasp_object.h
+++ b/src/hasp/hasp_object.h
@@ -100,6 +100,17 @@ lv_obj_t* hasp_find_obj_from_parent_id(lv_obj_t* parent, uint8_t objid);
 lv_obj_t* hasp_find_obj_from_page_id(uint8_t pageid, uint8_t objid);
 bool hasp_find_id_from_obj(const lv_obj_t* obj, uint8_t* pageid, uint8_t* objid);
 
+#if USE_OBJ_ALIAS > 0
+/**
+ * Find object with given alias
+ * @param obj pointer to perent object
+ * @param alias hash to be searched for
+ * @param level level of the search depth, is incremented in each level
+ * @return pointer to found object or NULL if nothing was found
+ */
+lv_obj_t* hasp_find_obj_from_alias(const lv_obj_t* obj, uint16_t alias, uint8_t level = 0);
+#endif  // #if USE_OBJ_ALIAS
+
 void hasp_object_tree(const lv_obj_t* parent, uint8_t pageid, uint16_t level);
 
 void object_dispatch_state(uint8_t pageid, uint8_t btnid, const char* payload);

--- a/src/hasp/hasp_parser.cpp
+++ b/src/hasp/hasp_parser.cpp
@@ -169,11 +169,16 @@ void Parser::get_event_name(uint8_t eventid, char* buffer, size_t size)
 
 /* 16-bit hashing function http://www.cse.yorku.ca/~oz/hash.html */
 /* all possible attributes are hashed and checked if they are unique */
-uint16_t Parser::get_sdbm(const char* str)
+uint16_t Parser::get_sdbm(const char* str, uint16_t len)
 {
     uint16_t hash = 0;
-    while(char c = tolower(*str++))
-        if(c > 57 || c < 48) hash = c + (hash << 6) - hash; // exclude numbers which can cause collisions
+    char c;
+    while( (c = tolower(*str++) ) && len) {
+        if(c > 57 || c < 48) {
+            hash = c + (hash << 6) - hash; // exclude numbers which can cause collisions
+        }
+        len--;
+    }
     return hash;
 }
 

--- a/src/hasp/hasp_parser.h
+++ b/src/hasp/hasp_parser.h
@@ -15,7 +15,7 @@ class Parser {
     static bool get_event_state(uint8_t eventid);
     static void get_event_name(uint8_t eventid, char* buffer, size_t size);
     static uint8_t get_action_id(const char* action);
-    static uint16_t get_sdbm(const char* str);
+    static uint16_t get_sdbm(const char* str, uint16_t len = UINT16_MAX);
     static bool is_true(const char* s);
     static bool is_true(JsonVariant json);
     static bool is_only_digits(const char* s);

--- a/src/hasp_gui.cpp
+++ b/src/hasp_gui.cpp
@@ -352,7 +352,12 @@ void guiSetup()
 #endif
 
     /* Initialize Global progress bar*/
+#if USE_OBJ_ALIAS > 0
+    lv_obj_user_data_t udata = (lv_obj_user_data_t){10, 0, 10, NULL, 0};
+#else
     lv_obj_user_data_t udata = (lv_obj_user_data_t){10, 0, 10};
+#endif  // #if USE_OBJ_ALIAS > 0
+
     lv_obj_t* bar            = lv_bar_create(lv_layer_sys(), NULL);
     lv_obj_set_user_data(bar, udata);
     lv_obj_set_hidden(bar, true);

--- a/src/hasp_oobe.cpp
+++ b/src/hasp_oobe.cpp
@@ -190,7 +190,11 @@ static void oobeSetupSsid(void)
 
     lv_coord_t leftmargin, topmargin, voffset;
     lv_align_t labelpos;
+#if USE_OBJ_ALIAS > 0
+    lv_obj_user_data_t udata = {0, 0, 0, NULL, 0};
+#else
     lv_obj_user_data_t udata = {0, 0, 0};
+#endif
 
     lv_disp_t* disp = lv_disp_get_default();
     if(disp->driver.hor_res <= disp->driver.ver_res) {


### PR DESCRIPTION
Object alias

An alias can be assigned to each object. This means that the object can be accessed not only with the page number and ID (pXbY) but also by alias. The advantage of this is that the position of the object does not have to be known. For example, it is possible to change the status of a button on several plates with a single command via MQTT, even though the button has a different position on different plates.
When using the alias, the command must be preceded by an '@', for example "@Alpha.text"

To be able to use alias, USE_OBJ_ALIAS must be greater than zero when compiling.

#define USE_OBJ_ALIAS 1

Example :

pages.jsonl

{"page":1,"comment":"---------- Page 1 ----------"}
{"id":0,"bg_color":"#000050","text_color":"#555555"}
{"page":1,"id":10,"obj":"label","x":10,"y":10,"w":120,"h":36,"text":"Red","text_font":24,"bg_color":"#ff0000","bg_opa":255,"radius":7,"align":"center","alias":"Alpha"}
{"page":1,"id":11,"obj":"label","x":10,"y":50,"w":120,"h":36,"text":"Green","text_font":24,"bg_color":"#00ff00","bg_opa":255,"radius":7,"align":"center","alias":"Bravo"}
{"page":1,"id":17,"obj":"btn","x":245,"y":200,"w":75,"h":70,"toggle":false,"text":"\uE05D","text_font":32,"bg_color":"#005000","alias":"Marsman","action": {"down": "@alpha.text example"}} 


MQTT

Topic : hasp/plates/command/@bravo.bg_color
Payload : #888800
